### PR TITLE
Fix out-of-bounds write caused by an integer overflow

### DIFF
--- a/Main.c
+++ b/Main.c
@@ -3,7 +3,7 @@
 
 #include "Dictionary.h"
 
-static int randInt() { return (rand() * rand()); }
+static unsigned int randInt() { return (rand() * rand()); }
 
 int main() {
     enum { DataSize = 8 };


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).